### PR TITLE
Fix for jQuery.outerWidth(...) shortcoming when initializing invisible sliders.

### DIFF
--- a/lemmon-slider.js
+++ b/lemmon-slider.js
@@ -22,24 +22,40 @@
 		// Initialzie plugin
 		//
 		init : function( options ){
-			
+
 			var options = $.extend( {}, $.fn.lemmonSlider.defaults, options );
-			
+
 			return this.each(function(){
-				
+
 				var $slider = $( this ),
 				    data = $slider.data( 'slider' );
-				
+
 				if ( ! data ){
-					
+
 					var $sliderContainer = $slider.find( options.slider ),
 					    $sliderControls = $slider.next().filter( '.controls' ),
 					    $items = $sliderContainer.find( options.items ),
 					    originalWidth = 1;
 
+                    if (!$slider.is(':visible'))
+                    {
+                        $('<style type="text/css">' +
+                              '.lemmon-init' +
+                              '{' +
+                              'display: block;' +
+                              'position: absolute;' +
+                              'left: -1000px' +
+                              '}' +
+                              '</style>').appendTo('head');
+
+                        $slider.addClass('lemmon-init');
+                    }
+
 					$items.each(function(){ originalWidth += $( this ).outerWidth( true ) });
 					$sliderContainer.width( originalWidth );
-					
+
+                    $slider.removeClass('lemmon-init');
+
 					// slide to last item
 					if ( options.slideToLast ) $sliderContainer.css( 'padding-right', $slider.width() );
 
@@ -48,17 +64,17 @@
 
 						originalWidth = originalWidth * 3;
 						$sliderContainer.width( originalWidth );
-						
+
 						$items.clone().addClass( '-after' ).insertAfter( $items.filter(':last') );
 						$items.filter( ':first' ).before( $items.clone().addClass('-before') );
 
 					    $items = $sliderContainer.find( options.items );
 
 					}
-					
+
 					$slider.items = $items;
 					$slider.options = options;
-					
+
 					// first item
 					//$items.filter( ':first' ).addClass( 'active' );
 
@@ -195,7 +211,7 @@
 					});
 
 					//if ( typeof $slider.options.create == 'function' ) $slider.options.create();
-					
+
 					$slider.data( 'slider', {
 						'target'  : $slider,
 						'options' : options
@@ -204,34 +220,34 @@
 				}
 
 			});
-			
+
 		},
 		//
 		// Destroy plugin
 		//
 		destroy : function(){
-			
+
 			return this.each(function(){
-				
+
 				var $slider = $( this ),
 				    $sliderControls = $slider.next().filter( '.controls' ),
 				    data = $slider.data( 'slider' );
-				
+
 				$slider.unbind( 'nextSlide' );
 				$slider.unbind( 'prevSlide' );
 				$slider.unbind( 'nextPage' );
 				$slider.unbind( 'prevPage' );
 				$slider.unbind( 'slideTo' );
-				
+
 				$sliderControls.find( '.next-slide' ).unbind( 'click' );
 				$sliderControls.find( '.prev-slide' ).unbind( 'click' );
 				$sliderControls.find( '.next-page' ).unbind( 'click' );
 				$sliderControls.find( '.next-page' ).unbind( 'click' );
-				
+
 				$slider.removeData( 'slider' );
-				
+
 			});
-			
+
 		}
 		//
 		//
@@ -241,9 +257,9 @@
 	// Private functions
 	//
 	function slideTo( e, $slider, x, i, t ){
-		
+
 		$slider.items.filter( 'li:eq(' + i + ')' ).addClass( 'active' ).siblings( '.active' ).removeClass( 'active' );
-		
+
 		if ( typeof t == 'undefined' ){
 			t = 'fast';
 		}
@@ -256,12 +272,12 @@
 			$slider.scrollLeft( x );
 			checkInfinite( $slider );
 		}
-		
+
 		//if ( typeof $slider.options.slide == 'function' ) $slider.options.slide( e, i, time );
-		
+
 	}
 	function checkInfinite( $slider ){
-		
+
 		var $active = $slider.items.filter( '.active' );
 		if ( $active.hasClass( '-before' ) ){
 
@@ -276,9 +292,9 @@
 			$active.removeClass( 'active' );
 			$active = $slider.items.filter( ':not(.-before):eq(' + i + ')' ).addClass( 'active' );
 			$slider.scrollLeft( $slider.scrollLeft() + $active.position().left );
-			
+
 		}
-		
+
 	}
 	//
 	// Debug
@@ -289,7 +305,7 @@
 	//
 	//
 	//
-	$.fn.lemmonSlider = function( method ){  
+	$.fn.lemmonSlider = function( method ){
 
 		if ( methods[method] ) {
 			return methods[ method ].apply( this, Array.prototype.slice.call( arguments, 1 ));
@@ -304,14 +320,14 @@
 	//
 	//
 	$.fn.lemmonSlider.defaults = {
-		
+
 		'items'       : '> *',
 		'loop'        : true,
 		'slideToLast' : false,
 		'slider'      : '> *:first',
 		// since 0.2
 		'infinite'    : false
-		
+
 	}
 
 })( jQuery );


### PR DESCRIPTION
I have a use case where a slider his hidden initially and becomes active depending on user activity. Lemmon slider depends on jQuery.outerWidth(...) to determine how to size the slider, but this function does not work on elements whose parents have the display:none property.

The solution is to temporarily add a class that makes the slider visible off-screen while the jQuery.outerWidth(...) calculations take place, then removing the class when it is done.
